### PR TITLE
SLING-12540 Prepare generate_javadoc_for_release.sh for Sling 13

### DIFF
--- a/generate_javadoc_for_release.sh
+++ b/generate_javadoc_for_release.sh
@@ -109,8 +109,6 @@ fi
 echo "Starting javadoc generation"
 
 pushd $WORKDIR
-# This might fail due to duplications in the classpath (see https://issues.apache.org/jira/browse/SLING-6766?focusedCommentId=16358298&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16358298)
-# The classpath order is unfortunately not predictable with m-j-p 3.0.0 (https://issues.apache.org/jira/browse/MJAVADOC-513)
 mvn -DexcludePackageNames="*.impl:*.internal:*.jsp:sun.misc:*.juli:*.testservices:*.integrationtest:*.maven:javax.*:org.osgi.*" \
          org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:aggregate -Dnotimestamp=true -Dignore.javadocjdk=true
 popd

--- a/generate_javadoc_for_release.sh
+++ b/generate_javadoc_for_release.sh
@@ -34,10 +34,9 @@ for artifact in $artifacts; do
     artifact_repo=$(echo $artifact_name | tr '.' '-')
     artifact_repo="sling-${artifact_repo}"
 
-    # - don't document Slingshot sample
+    # - don't document Slingshot sample or Sling Starter Content
     # - threaddump was renamed and tag history is lost
-    # - validation core fails on Javadoc aggregation, but does not export anything
-    if [[ ${artifact_name} == *slingshot || ${artifact_name} = "org.apache.sling.extensions.threaddump" || ${artifact_name} == "org.apache.sling.validation.core" ]]; then
+    if [[ ${artifact_name} == *slingshot || ${artifact_name} == "org.apache.sling.starter.content" || ${artifact_name} = "org.apache.sling.extensions.threaddump" ]]; then
         continue;
     fi
 

--- a/generate_javadoc_for_release.sh
+++ b/generate_javadoc_for_release.sh
@@ -86,6 +86,7 @@ echo "  <name>Apache Sling</name>" >> $POM
 echo >> $POM
 echo "  <properties>" >> $POM
 echo "    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>" >> $POM
+echo "    <maven.compiler.target>11</maven.compiler.target>" >> $POM
 echo "  </properties>" >> $POM
 echo >> $POM
 echo " <modules> " >> $POM
@@ -110,7 +111,7 @@ echo "Starting javadoc generation"
 
 pushd $WORKDIR
 mvn -DexcludePackageNames="*.impl:*.internal:*.jsp:sun.misc:*.juli:*.testservices:*.integrationtest:*.maven:javax.*:org.osgi.*" \
-         org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:aggregate -Dnotimestamp=true -Dignore.javadocjdk=true
+         org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:aggregate -Dnotimestamp=true -Dignore.javadocjdk=true -Ddoclint=none
 popd
 
 echo "Generated Javadocs can be found in $WORKDIR/target/site/apidocs/"

--- a/generate_javadoc_for_release.sh
+++ b/generate_javadoc_for_release.sh
@@ -101,7 +101,7 @@ popd
 if [ ! -f $WORKDIR/src/main/javadoc/overview.html ] ; then
     echo "Downloading javadoc overview file"
     mkdir -p $WORKDIR/src/main/javadoc
-    wget https://svn.apache.org/repos/asf/sling/trunk/src/main/javadoc/overview.html -O $WORKDIR/src/main/javadoc/overview.html
+    cp javadoc/overview.html $WORKDIR/src/main/javadoc/overview.html
 fi
 
 # generate javadoc

--- a/generate_javadoc_for_release.sh
+++ b/generate_javadoc_for_release.sh
@@ -112,7 +112,7 @@ pushd $WORKDIR
 # This might fail due to duplications in the classpath (see https://issues.apache.org/jira/browse/SLING-6766?focusedCommentId=16358298&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16358298)
 # The classpath order is unfortunately not predictable with m-j-p 3.0.0 (https://issues.apache.org/jira/browse/MJAVADOC-513)
 mvn -DexcludePackageNames="*.impl:*.internal:*.jsp:sun.misc:*.juli:*.testservices:*.integrationtest:*.maven:javax.*:org.osgi.*" \
-         org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:aggregate -Dnotimestamp=true -Dignore.javadocjdk=true
+         org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:aggregate -Dnotimestamp=true -Dignore.javadocjdk=true
 popd
 
 echo "Generated Javadocs can be found in $WORKDIR/target/site/apidocs/"

--- a/generate_javadoc_for_release.sh
+++ b/generate_javadoc_for_release.sh
@@ -22,8 +22,8 @@ artifacts=$(cat $WORKDIR/feature.json | jq -r '.bundles[].id | select(startswith
 
 # add additional artifacts which are not part of the launchpad
 # https://issues.apache.org/jira/browse/SLING-6766
-artifacts+=" adapter-annotations:1.0.0"
-artifacts+=" org.apache.sling.servlets.annotations:1.1.0"
+artifacts+=" org.apache.sling.adapter.annotations:2.0.0"
+artifacts+=" org.apache.sling.servlets.annotations:1.2.6"
 
 # checkout tags
 for artifact in $artifacts; do
@@ -79,7 +79,7 @@ echo >> $POM
 echo "  <parent>" >> $POM
 echo "    <groupId>org.apache</groupId>" >> $POM
 echo "    <artifactId>apache</artifactId>" >> $POM
-echo "    <version>8</version>" >> $POM
+echo "    <version>33</version>" >> $POM
 echo "  </parent>" >> $POM
 echo >> $POM
 echo "  <name>Apache Sling</name>" >> $POM

--- a/javadoc/overview.html
+++ b/javadoc/overview.html
@@ -1,0 +1,44 @@
+<body>
+
+<p><b>Apache Sling &#0153;</b>
+ is an innovative web framework that is intended to bring back the fun to web development.</p> 
+ 
+<h1>Apache Sling in five bullets points</h1> 
+ 
+<uL> 
+	<li>REST based web framework</li> 
+	<li>Content-driven, using a JCR content repository</li> 
+	<li>Powered by OSGi</li> 
+	<li>Scripting inside, multiple languages (JSP, server-side javascript, Scala, etc.)</li> 
+	<li>Apache Open Source project</li> 
+</ul> 
+ 
+ 
+<h1>Apache Sling in a hundred words</h1> 
+ 
+<p>Apache Sling is a web framework that uses a <a
+href="http://en.wikipedia.org/wiki/JSR-170">Java Content Repository</a>,
+such as <a href="http://jackrabbit.apache.org/" class="external-link"
+rel="nofollow">Apache Jackrabbit</a>, to store and manage content.</p> 
+ 
+<p>Sling applications use either scripts or Java servlets, selected based
+on simple name conventions, to process HTTP requests in a RESTful way.</p> 
+ 
+<p>The embedded <a href="http://felix.apache.org/">Apache Felix</a> OSGi
+framework and console provide a dynamic runtime environment, where code and
+content bundles can be loaded, unloaded and reconfigured at runtime.</p> 
+ 
+<p>As the first web framework dedicated to <a
+href="http://jcp.org/en/jsr/detail?id=170">JSR-170</a> Java Content
+Repositories, Sling makes it very simple to implement simple applications,
+while providing an enterprise-level framework for more complex
+applications. </p> 
+
+
+<h1>JavaDoc generation</h1>
+
+<p> 
+This documentation has been created using the <a href="https://svn.apache.org/repos/asf/sling/trunk/tooling/release/generate_javadoc_for_release.sh">generate_javadoc_for_release.sh</a>
+script.
+</p> 
+</body>

--- a/javadoc/overview.html
+++ b/javadoc/overview.html
@@ -1,6 +1,6 @@
 <body>
 
-<p><b>Apache Sling &#0153;</b>
+<p><b>Apache Sling ™</b>
  is an innovative web framework that is intended to bring back the fun to web development.</p> 
  
 <h1>Apache Sling in five bullets points</h1> 
@@ -18,8 +18,8 @@
  
 <p>Apache Sling is a web framework that uses a <a
 href="http://en.wikipedia.org/wiki/JSR-170">Java Content Repository</a>,
-such as <a href="http://jackrabbit.apache.org/" class="external-link"
-rel="nofollow">Apache Jackrabbit</a>, to store and manage content.</p> 
+such as <a href="http://jackrabbit.apache.org/">Apache Jackrabbit</a>,
+to store and manage content.</p> 
  
 <p>Sling applications use either scripts or Java servlets, selected based
 on simple name conventions, to process HTTP requests in a RESTful way.</p> 
@@ -38,7 +38,7 @@ applications. </p>
 <h1>JavaDoc generation</h1>
 
 <p> 
-This documentation has been created using the <a href="https://svn.apache.org/repos/asf/sling/trunk/tooling/release/generate_javadoc_for_release.sh">generate_javadoc_for_release.sh</a>
+This documentation has been created using the <a href="https://github.com/apache/sling-tooling-release/blob/master/generate_javadoc_for_release.sh">generate_javadoc_for_release.sh</a>
 script.
 </p> 
 </body>


### PR DESCRIPTION
* update to Apache Parent 33
* update artifacts for adapter and servlet annotations
* put overview.html in this repo and fix markup
* update to latest maven-javadoc-plugin
* set Java Compile/Source version for aggregate build to Java 11
* skip linting of generated javadocs
* update list of excluded modules